### PR TITLE
Fix missing JSON handling in summarize route

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -6,7 +6,6 @@ import time
 import feedparser
 
 from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
-import torch
 
 # === Flask Setup ===
 app = Flask(__name__)
@@ -32,7 +31,7 @@ news_cache = {}
 # === Summarization Route ===
 @app.route("/summarize", methods=["POST"])
 def summarize():
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     text = data.get("text", "")
 
     if not text:
@@ -55,7 +54,6 @@ def summarize_internal(text):
 
 # === Fetch News from RSS and Summarize ===
 def fetch_and_summarize_news():
-    global news_cache
     new_data = {}
 
     print("[+] Fetching and summarizing news from Google RSS...")


### PR DESCRIPTION
## Summary
- avoid crash if POST `/summarize` receives no JSON payload
- drop unused `torch` import
- minor cleanup of RSS update helper

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686d4431c5a483339e85935c728ca1d4